### PR TITLE
fixing button flickering if the message queue was empty

### DIFF
--- a/src/UniMoveController.cs
+++ b/src/UniMoveController.cs
@@ -254,8 +254,8 @@ public class UniMoveController : MonoBehaviour
 
             // The events are not really working from the PS Move Api. So we do our own with the prevButtons
             //psmove_get_button_events(handle, ref pressed, ref released);
+            currentButtons = buttons;
         }
-        currentButtons = buttons;
 
 
         // For acceleration, gyroscope, and magnetometer values, we look at only the last value in the queue.


### PR DESCRIPTION
if you have very high frame rates (for example, if you comment out the psmove_tracker_updateimage), the down/up/pressed states of buttons would not be reliable.